### PR TITLE
Fix ./server.sh and fix forever/server namespace clash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 name: Test suite
 on:
   push:
-  pull_request:
+  # pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ You should see an OAuth URL appear in the console. Copy and open in your browser
 
 ## Running forever
 
-You can srun the bot with `yarn start`, but the bundled `forever` library will restart the bot if it crashes or disconnects:
+You can run the bot with `yarn start`, but the bundled `forever` library will restart the bot if it crashes or disconnects. The `./server.sh` script is a wrapper around it and can be launched using:
 
 ```
-yarn forever
+SERVER_UID=helium yarn server
 ```
+
+You can run multiple bots on same machine by changing `SERVER_UID`
 
 ## Add your hotspots
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "node bot.js",
     "test": "node test.js",
-    "forever": "./server.sh",
+    "server": "./server.sh",
     "watch": "watchexec -r -e js -- yarn start"
   },
   "engines": {

--- a/server.sh
+++ b/server.sh
@@ -2,6 +2,13 @@
 # Helper script to start a permanent node server
 
 source .env
-forever stop "$SERVER_UID"
-forever --uid "$SERVER_UID" -a start bot.js
-tail -f /home/pi/.forever/${SERVER_UID}.log
+
+if [ -z $SERVER_UID ]; then
+  echo "$0: export SERVER_UID e.g. 'helium'"
+  exit 1
+fi
+
+echo "SERVER_UID=$SERVER_UID"
+yarn run forever stop "$SERVER_UID"
+yarn run forever --uid "$SERVER_UID" -a start bot.js
+tail -F $HOME/.forever/${SERVER_UID}.log


### PR DESCRIPTION
I don't have node_modules bin in my PATH so running `forever` doesn't work, gotta use `yarn run forever`

But `yarn run forever` wasn't working because I'd defined a `forever` script in package.json

Lastly, error out if `SERVER_UID` is not set, and document that in the README
